### PR TITLE
Add a default return when a controller didnt implement process_request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage/
 *.gem
 .bundle
+*.swp

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -1,7 +1,23 @@
+# This is the default action that will handle the "page internal server error" (500) if a process_request didnt implemented. 
+class ProcessRequestor
+
+  # Once the application receives a new request, the router will decide wich
+  # controller should process that request and will execute this method for
+  # the chosen controller. So this is the most important method of this class
+  # and every controller should overwrite it to implement it's business
+  # logic.
+  def process_request
+    @response.body = '500 - Internal Server Error'
+    @response.content_type = 'text/plain'
+    @response.status = 500
+  end
+
+end
+
 # Abstract controller class with some helper methods. ALL your controllers
 # MUST use this one as a superclass.
 
-class RackStep::Controller
+class RackStep::Controller < ProcessRequestor
 
   # The request will be injected here.
   attr_accessor :request
@@ -14,14 +30,6 @@ class RackStep::Controller
     @response.body = ''
     @response.content_type = 'application/json'
     @response.status = 200
-  end
-
-  # Once the application receives a new request, the router will decide wich
-  # controller should process that request and will execute this method for
-  # the chosen controller. So this is the most important method of this class
-  # and every controller should overwrite it to implement it's business
-  # logic.
-  def process_request
   end
 
   # RackStep will always execute this method before delegating the request
@@ -41,7 +49,6 @@ class RackStep::Controller
   end
 
 end
-
 
 # This is the default controller that will handle the "page not found" (404). 
 # The user may overwrite this by creating new route to 'notfound'.

--- a/test/test_invalid_route.rb
+++ b/test/test_invalid_route.rb
@@ -13,4 +13,11 @@ class InvalidRoutesTest < RackStepTest
     assert_equal 404, request.status
   end
 
+  def test_controller_without_process_request
+    # Requesting the route that didnt implemented the process_request method.
+    request = @requester.get '/processRequestorNotImplemented'
+    # The response should be status 500
+    assert_equal 500, request.status
+  end
+
 end

--- a/test/util/sample_app.rb
+++ b/test/util/sample_app.rb
@@ -94,6 +94,11 @@ class Redirector < RackStep::Controller
 end
 
 
+# Creating the controller that wont implement the process_request method
+class ProcessRequestorNotImplemented < RackStep::Controller
+end
+
+
 # Creating the app class and adding a few routes.
 class SampleApp < RackStep::App
 
@@ -113,6 +118,8 @@ class SampleApp < RackStep::App
   # Route to test redirect_to.
   add_route('GET', 'testRedirect', Redirector)
 
+  # Route to test controller that didnt implemented process_request.
+  add_route('GET', 'processRequestorNotImplemented', ProcessRequestorNotImplemented)
 end
 
 


### PR DESCRIPTION
Return an Internal Server Error when a controller that should implement process_request didnt implement this method.